### PR TITLE
Add support for bundled products in shortcodes

### DIFF
--- a/includes/admin/settings/register.php
+++ b/includes/admin/settings/register.php
@@ -52,6 +52,12 @@ function edd_cr_add_settings( $settings ) {
 				'type'  => 'checkbox',
 			),
 			array(
+				'id'    => 'edd_content_restriction_include_bundled_products',
+				'name'  => __( 'Include Bundled Products', 'edd-cr' ),
+				'desc'  => __( 'Should products purchased as part of a bundle be considered purchased when determining access rights?', 'edd-cr' ),
+				'type'  => 'checkbox'
+			),
+			array(
 				'id'          => 'edd_cr_single_resriction_message',
 				'name'        => __( 'Single Restriction Message', 'edd-cr' ),
 				'desc'        => __( 'When access is restricted by a single product, this message will show to the user when they do not have access. <code>{product_name}</code> will be replaced by the restriction requirements.', 'edd-cr' ),

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -103,7 +103,7 @@ function edd_cr_user_can_access( $user_id = false, $restricted_to, $post_id = fa
 
 						if ( in_array( $data['download'], $bundled ) ) {
 							$has_access = true;
-							continue;
+							break;
 						}
 					}
 				}

--- a/includes/user-functions.php
+++ b/includes/user-functions.php
@@ -93,6 +93,21 @@ function edd_cr_user_can_access( $user_id = false, $restricted_to, $post_id = fa
 					}
 				}
 			}
+
+			if ( ! $has_access && is_user_logged_in() && edd_get_option( 'edd_content_restriction_include_bundled_products', false ) ) {
+				$purchased = edd_get_users_purchased_products( $user_id );
+
+				foreach ( $purchased as $item ) {
+					if ( edd_is_bundled_product( $item->ID ) ) {
+						$bundled = (array) edd_get_bundled_products( $item->ID );
+
+						if ( in_array( $data['download'], $bundled ) ) {
+							$has_access = true;
+							continue;
+						}
+					}
+				}
+			}
 		}
 
 		if ( $has_access == false ) {


### PR DESCRIPTION
Fixes #57 
I couldn't find a more optimized way of looking this up, but the way I'm doing it feels a bit... unoptimal. Is there a better way?